### PR TITLE
Support multiple pods

### DIFF
--- a/src/spaceone/supervisor/service/supervisor_service.py
+++ b/src/spaceone/supervisor/service/supervisor_service.py
@@ -196,7 +196,8 @@ class SupervisorService(BaseService):
             'spaceone.supervisor.domain_id': params['domain_id'],
             'spaceone.supervisor.plugin.plugin_name': plugin_info.name,
             'spaceone.supervisor.plugin.image': plugin_info.image,
-            'spaceone.supervisor.plugin.version': params['version']
+            'spaceone.supervisor.plugin.version': params['version'],
+            'spaceone.supervisor.plugin.service_type': plugin_info.service_type
         }
         # Determine port mapping
         host_port = self._supervisor_mgr.find_host_port()


### PR DESCRIPTION
In K8S environment, replica defines number of pod for specific plugin

Example config
  PLUGIN:
    backend: KubernetesConnector
    namespace: exp-supervisor
    start_port: 50051
    end_port: 50052
    headless: false
    replica:
      inventory.collector: 4

Signed-off-by: Choonho Son <choonhoson@megazone.com>